### PR TITLE
[fix]チャットの表示テキストの長さを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ https://docs.google.com/spreadsheets/d/1eZLa4jBUc4S43218TsmHao45qh9Jr4VH5_h4vw2z
 
 ## チャレンジ要素一覧
 
-https://docs.google.com/spreadsheets/d/1_786mkUThoSpcJTnSFQ0l2vefNO2-E3xioEtBcorOh4/edit#gid=0  
-- 　↑↑↑　上記のURLに、実装した機能について記載しております！！！
+https://docs.google.com/spreadsheets/d/1_786mkUThoSpcJTnSFQ0l2vefNO2-E3xioEtBcorOh4/edit#gid=0
+- ↑↑↑　上記のURLに、実装した機能について記載しております！！！
 ## 開発環境
 
 - OS：Linux(CentOS)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   validates :age, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 18 }
   # 正規表現を利用して、都道府県のどれかの文字をつけないとエラーを出るようにしている。
   validates :address, format: { with: /.*[都道府県]/ }
+  validates :playing_game, format: { with: /\w+::\w/ }
   # ユーザールームを使うことによってuserとroomの多対多の関係を成立させている。
   has_many :user_rooms, dependent: :destroy
   # Userは沢山チャットをするので複数のchatt をする chatは一人のユーザーしか持てない。

--- a/app/views/chats/_comment.html.erb
+++ b/app/views/chats/_comment.html.erb
@@ -1,9 +1,9 @@
  <% if chat.user_id == current_user.id %>
  <tbody>
   <tr class="p-0 m-0">
-    <th class="p-0-m-0"><p style="text-align: left;" class="m-0 p-0">
+    <th class="p-0-m-0" colspan="2"><p style="text-align: left;" class="m-0 p-0">
       <%= link_to user_path(chat.user) do %>
-      <%= attachment_image_tag chat.user , :profile_image, :fill,40,40, fallback: "no_image.jpg", size: "40x40", class: "rounded-circle" %><% end %>
+      <%= attachment_image_tag chat.user, :profile_image, :fill,40,40, fallback: "no_image.jpg", size: "40x40", class: "rounded-circle" %><% end %>
       <%= chat.message %><%= attachment_image_tag chat, :item_image, :fill,100,100 %><br/>
       <small class="text-muted"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></small></p></th>
     <th></th>
@@ -11,9 +11,9 @@
   <% else %>
   <tr>
     <th></th>
-    <th class="p-0 m-0"><p style="text-align: right;" class="m-0 p-0">
+    <th class="p-0 m-0" colspan="2"><p style="text-align: right;" class="m-0 p-0">
       <%= link_to user_path(chat.user) do %>
-      <%= attachment_image_tag chat.user , :profile_image, :fill,40,40, fallback: "no_image.jpg", size: "40x40", class: "rounded-circle" %><% end %>
+      <%= attachment_image_tag chat.user, :profile_image, :fill,40,40, fallback: "no_image.jpg", size: "40x40", class: "rounded-circle" %><% end %>
       <%= chat.message %><%= attachment_image_tag chat, :item_image, :fill,100,100 %><br/><small class="text-muted"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></small></p></th>
   </tr>
 </tbody>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,7 +15,7 @@
               <li class="list-group-item"><%= f.label :年齢（年齢確認あり） %><%= f.text_field :age, placeholder: "18以上の方のみ！！" %></li>
               <li class="list-group-item"><%= f.label :住所（都道府県） %><%= f.text_field :address %></li>
               <li class="list-group-item"><%= f.label :性別： %><%= f.label :男性 %><%= f.radio_button :sex, :man %><%= f.label :女性 %><%= f.radio_button :sex, :woman%></li>
-              <li class="list-group-item"><%= f.label :ゲーム機種：プレイ中のゲーム %><%= f.text_field :playing_game, placeholder: "[：]を忘れずに！！" %></li>
+              <li class="list-group-item"><%= f.label :ゲーム機種：プレイ中のゲーム %><%= f.text_field :playing_game, placeholder: "[::]を忘れずに！！" %></li>
               <li class="list-group-item"> <%= f.label :メールアドレス %><%= f.email_field :email, autofocus: true, autocomplete: "email" %></li>
               <li class="list-group-item"><%= f.label :パスワード %>
               <% if @minimum_password_length %>(最低6文字以上)


### PR DESCRIPTION
チャットの表示できる長さをより長くできるようにtableタグのところが、<th>一個分の長さだったのをcolspan＝２を用いて倍の長さに調整しました。また、playing_gameのユーザ登録のところを「：：」をしっかりつけてもらうようにvalidatesにしっかりつけてもらうようにformatを加えました。